### PR TITLE
#925 governing auton name max char

### DIFF
--- a/components/dao/DaoNamingFields.vue
+++ b/components/dao/DaoNamingFields.vue
@@ -37,7 +37,7 @@
         class="mt-2"
         counter
         style="max-width: 450px"
-        maxlength="64"
+        maxlength="20"
         :rules="[rules.required, rules.min, rules.maxgoverningName]"
         v-model="governingNameValue"
       ></v-text-field>
@@ -81,7 +81,7 @@ export default {
     rules: {
       required: (value) => !!value || "Required.",
       min: (v) => v?.length >= 2 || "Min 2 characters",
-      maxgoverningName: (v) => v?.length <= 64 || "Max 64 characters",
+      maxgoverningName: (v) => v?.length <= 20 || "Max 64 characters",
       maxName: (v) => v?.length <= 16 || "Max 16 characters",
     },
   }),

--- a/components/dao/DaoNamingFields.vue
+++ b/components/dao/DaoNamingFields.vue
@@ -81,7 +81,7 @@ export default {
     rules: {
       required: (value) => !!value || "Required.",
       min: (v) => v?.length >= 2 || "Min 2 characters",
-      maxgoverningName: (v) => v?.length <= 20 || "Max 64 characters",
+      maxgoverningName: (v) => v?.length <= 20 || "Max 20 characters",
       maxName: (v) => v?.length <= 16 || "Max 16 characters",
     },
   }),


### PR DESCRIPTION
Fixes https://github.com/Kalipo-BV/kalipo-core/issues/925

20 Characters for the Auton name is actually reasonable, and saves space and fees on the blockchain, so it's better to fix the issue in the front end.

